### PR TITLE
Test for String.trim

### DIFF
--- a/__tests__/String/trim.test.ts
+++ b/__tests__/String/trim.test.ts
@@ -7,7 +7,7 @@ describe('trim', () => {
     expectType<string>(S.trim('text'))
   })
 
-  it('returns a new string with leading and trailing whitespace removed from str', () => {
+  it('returns a new string with leading and trailing whitespace removed from string', () => {
     expect(S.trim('  text')).toEqual('text')
   })
 })

--- a/__tests__/String/trim.test.ts
+++ b/__tests__/String/trim.test.ts
@@ -1,0 +1,13 @@
+import { expectType } from 'ts-expect'
+
+import { S } from '../..'
+
+describe('trim', () => {
+  it('provides correct types', () => {
+    expectType<string>(S.trim('test-text'))
+  })
+
+  it('returns a new string with leading and trailing whitespace removed from str', () => {
+    expect(S.trim('    test-text')).toEqual('test-text')
+  })
+})

--- a/__tests__/String/trim.test.ts
+++ b/__tests__/String/trim.test.ts
@@ -10,4 +10,8 @@ describe('trim', () => {
   it('returns a new string with leading and trailing whitespace removed from string', () => {
     expect(S.trim('  text')).toEqual('text')
   })
+
+  it('*', () => {
+    expect(S.trim('  text')).toEqual('text')
+  })
 })

--- a/__tests__/String/trim.test.ts
+++ b/__tests__/String/trim.test.ts
@@ -4,10 +4,10 @@ import { S } from '../..'
 
 describe('trim', () => {
   it('provides correct types', () => {
-    expectType<string>(S.trim('test-text'))
+    expectType<string>(S.trim('text'))
   })
 
   it('returns a new string with leading and trailing whitespace removed from str', () => {
-    expect(S.trim('    test-text')).toEqual('test-text')
+    expect(S.trim('  text')).toEqual('text')
   })
 })

--- a/docs/api/generated/_string.mdx
+++ b/docs/api/generated/_string.mdx
@@ -288,3 +288,7 @@ Returns a new string with leading and trailing whitespace removed from `str`.
 ```ts
 function trim(str: string): string
 ```
+
+```ts
+S.trim('  text') // → 'text'
+```


### PR DESCRIPTION
I would like to add implementations for trimStart and trimEnd. Is it on the "roadmap"? 