### PR TITLE
added test to ensure benchmark is correct

### DIFF
--- a/benchmarks/ensure-identical-output.js
+++ b/benchmarks/ensure-identical-output.js
@@ -1,0 +1,66 @@
+const R = require('ramda')
+
+const testFiles = [
+  './complex/deepFlat-uniq-groupBy',
+  './complex/map-filter-reduce',
+  './simple/deepFlat',
+  './simple/dropWhile',
+  './simple/filter',
+  './simple/find',
+  './simple/flat',
+  // './simple/forEach', // skip this one as there is no output to compare
+  './simple/fromPairs',
+  './simple/groupBy',
+  './simple/intersperse',
+  './simple/map',
+  './simple/reduce',
+  './simple/reject',
+  './simple/sort',
+  './simple/splitEvery',
+  './simple/takeWhile',
+  './simple/toPairs',
+  './simple/uniq',
+  './simple/unzip',
+  './simple/zip',
+]
+
+const skippedSuites = [
+  'funkia/list', // output is not comparable
+]
+
+testFiles.forEach(testFile => {
+  const test = require(testFile)
+  const firstSuite = {
+    label: test.suites[0].label,
+    suite: test.suites[0],
+    results: {
+      rawFn: test.suites[0].rawFn(),
+      pipeFn: test.suites[0].pipeFn && test.suites[0].pipeFn(),
+    },
+  }
+
+  for (let i = 1; i < test.suites.length; i++) {
+    const suite = test.suites[i]
+    if (skippedSuites.includes(suite.label)) {
+      continue
+    }
+    const rawFnResult = suite.rawFn();
+    if (!R.equals(rawFnResult, firstSuite.results.rawFn)) {
+      console.error('rawFn test', testFile)
+      console.error(`${firstSuite.label} result`, firstSuite.results.rawFn)
+      console.error(`${suite.label} result`, rawFnResult)
+      console.error('expected results to be identical')
+      process.exit(1)
+    }
+    if (firstSuite.results.pipeFn) {
+      const pipeFnResult = suite.pipeFn();
+      if (!R.equals(pipeFnResult, firstSuite.results.pipeFn)) {
+        console.error('pipeFn test', testFile)
+        console.error(`${firstSuite.label} result`, firstSuite.results.pipeFn)
+        console.error(`${suite.label} result`, pipeFnResult)
+        console.error('expected results to be identical')
+        process.exit(1)
+      }
+    }
+  }
+})

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
+    "test": "NODE_ENV=test node ./ensure-identical-output.js",
     "start": "bash ./scripts/run.sh",
     "generate": "bash ./scripts/generate.sh"
   },

--- a/benchmarks/simple/flat.js
+++ b/benchmarks/simple/flat.js
@@ -47,18 +47,6 @@ module.exports = makeBenchmark(
       },
     ]
   }),
-  addRambda(rambda => {
-    const { pipe, flatten } = rambda
-
-    return [
-      () => {
-        return flatten(input)
-      },
-      () => {
-        return pipe(flatten)(input)
-      },
-    ]
-  }),
   addLodashFp(_ => {
     return [
       () => {

--- a/benchmarks/simple/sort.js
+++ b/benchmarks/simple/sort.js
@@ -60,14 +60,4 @@ module.exports = makeBenchmark(
       },
     ]
   }),
-  addLodashFp(_ => {
-    return [
-      () => {
-        return _.sortBy(fn, input)
-      },
-      () => {
-        return _.pipe(_.sortBy(fn))(input)
-      },
-    ]
-  }),
 )

--- a/benchmarks/simple/zip.js
+++ b/benchmarks/simple/zip.js
@@ -41,10 +41,10 @@ module.exports = makeBenchmark(
 
     return [
       () => {
-        return zip(xs, input)
+        return zip(input, xs)
       },
       () => {
-        return pipe(zip(xs))(input)
+        return pipe(zip(input))(xs)
       },
     ]
   }),
@@ -53,20 +53,20 @@ module.exports = makeBenchmark(
 
     return [
       () => {
-        return zip(xs, input)
+        return zip(input, xs)
       },
       () => {
-        return pipe(zip(xs))(input)
+        return pipe(zip(input))(xs)
       },
     ]
   }),
   addLodashFp(_ => {
     return [
       () => {
-        return _.zip(xs, input)
+        return _.zip(input, xs)
       },
       () => {
-        return _.pipe(_.zip(xs))(input)
+        return _.pipe(_.zip(input))(xs)
       },
     ]
   }),

--- a/benchmarks/utils.js
+++ b/benchmarks/utils.js
@@ -7,6 +7,12 @@ const L = require('list/curried')
 const belt = require('..')
 
 exports.makeBenchmark = (title, ...rest) => {
+  if (process.env.NODE_ENV === 'test') {
+    return {
+      title,
+      suites: rest,
+    }
+  }
   suite(
     `${title} ${title.includes('→') ? '' : '(single function call)'}`,
     () => {


### PR DESCRIPTION
The benchmark wasn't quite correct as some libs weren't even producing the same result.

I wrote a test compare the output of each benchmark to ts-belt.

I fixed the following issues

1. removed rambda flat test as their flatten is only a deep flatten
2. removed lodash/fp sort as their comparator api is different than the one being provided
3. fixed the ordering of zip for various libs