### PR TITLE
added bar to benchmark output

### DIFF
--- a/benchmarks/reporter.markdown.js
+++ b/benchmarks/reporter.markdown.js
@@ -24,6 +24,7 @@ module.exports = runner => {
       const successful = suite.filter('successful')
       const table = new Table()
 
+      const fractions = []
       suite.forEach(function (bench) {
         if (bench.aborted) {
           table.cell('status', '×')
@@ -49,16 +50,28 @@ module.exports = runner => {
           // Show percentual difference between this benchmark and the fastest.
           if (fastest.length !== successful.length) {
             let diff = 'fastest'
+            const fraction = bench.hz / fastest[0].hz
             if (bench !== fastest[0]) {
               diff =
-                '-' + ((1.0 - bench.hz / fastest[0].hz) * 100).toFixed(2) + '%'
+                '-' + ((1.0 - fraction) * 100).toFixed(2) + '%'
             }
             table.cell('diff', diff)
+            fractions.push(diff === 'fastest'
+              ? 1
+              : fraction
+            )
           }
         }
         table.newRow()
       })
-      console.log('\n```bash\n' + table.print() + '```\n')
+      const tableLines = table.print().split('\n')
+      const output = []
+      for (let i = 0; i < tableLines.length; i++) {
+        output.push(tableLines[i])
+        output.push(''.padStart(Math.floor(tableLines[0].length * fractions[i]), '█'))
+        output.push('\n')
+      }
+      console.log('\n```bash\n' + output.join('\n').trim() + '\n```\n')
       if (successful.length > 1) {
         if (fastest.length === successful.length) {
           console.log('→ No discernible winner\n')


### PR DESCRIPTION
I found it hard to read the benchmark full of numbers, so I added a bar under each result that allows humans to visually see how fast things are compared to each other.

<img width="657" alt="Screen Shot 2022-01-01 at 11 43 08" src="https://user-images.githubusercontent.com/463642/147858861-4e1ca595-43d7-4e8f-bca9-901358d2818c.png">


Attached full markdown output. This is a full benchmark running on MacBook Air M1 2020
[results.md](https://github.com/mobily/ts-belt/files/7798149/results.md)
