### PR TITLE
fix(Dict): D.keys correct type

### DIFF
--- a/src/Dict/Dict.ts
+++ b/src/Dict/Dict.ts
@@ -1,5 +1,5 @@
 import { Option } from '../Option'
-import { Array, ExtractValue } from '../types'
+import { Array, ExtractValue, StringKeyOf } from '../types'
 
 export declare function makeEmpty<T>(): T
 export declare function get<T, K extends keyof T>(
@@ -13,7 +13,7 @@ export declare function values<T extends string | number, R>(
 ): Array<R>
 export declare function keys<T extends Record<string, unknown>>(
   dict: T,
-): Array<keyof T>
+): Array<StringKeyOf<T>>
 export declare function merge<A, B>(fst: A, snd: B): A & B
 export declare function set<T, K extends string | number, V>(
   dict: T,

--- a/src/Dict/index.ts
+++ b/src/Dict/index.ts
@@ -1,6 +1,5 @@
 import { Option } from '../Option'
-import { ExtractValue } from '../types'
-import { Array } from '../types'
+import { ExtractValue, Array, StringKeyOf } from '../types'
 
 /** Creates an empty object. Alternative for `const obj = {} as SomeObjectType`. */
 
@@ -47,7 +46,7 @@ export declare function values<T extends string | number, R>(
 
 export declare function keys<T extends Record<string, unknown>>(
   dict: T,
-): Array<keyof T>
+): Array<StringKeyOf<T>>
 
 /** Creates a new object from an array of tuples (`[key, value]`). */
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export declare type ExtractValue<T> = Exclude<T, null | undefined>
 export declare type ExtractNested<T> = T extends Array<infer K>
   ? ExtractNested<K>
   : T
+export type StringKeyOf<T> = `${Extract<keyof T, string | number>}`
 export declare type GuardArray<T extends unknown> = Extract<
   T,
   Array<any>


### PR DESCRIPTION
This should fix issue with wrong types of `D.keys`. All keys are now converted to string in types:

```ts
const k = keys({
  a: 'hello',
  b: 'badw',
  c: 'gas',
  1: 'sadwd',
  2: 'dadw',
  3: 'dawdw',
})
```

before fix `readonly ("a" | "b" | "c" | 1 | 2 | 3)[]`


after fix `readonly ("a" | "b" | "c" | "1" | "2" | "3")[]`

I am not sure if I contributed correctly, I was not able to find guide how to do it, so I edited TS files directly, but they seems kind of autogenerated because `Dict/Dict.ts` and `Dict/index.ts` are nearly same, only `index` is without comments.

Closes #46 
Related to https://github.com/microsoft/TypeScript/issues/39543