### PR TITLE
Strongly type D.set for known keys

### DIFF
--- a/src/Dict/Dict.ts
+++ b/src/Dict/Dict.ts
@@ -15,7 +15,7 @@ export declare function keys<T extends Record<string, unknown>>(
   dict: T,
 ): Array<`${Extract<keyof T, string | number>}`>
 export declare function merge<A, B>(fst: A, snd: B): A & B
-export declare function set<T, K extends string | number, V>(
+export declare function set<T, K extends (keyof T | string | number), V extends (K extends keyof T ? T[K] : any)>(
   dict: T,
   key: K,
   value: V,


### PR DESCRIPTION
With existing typing, `D.set` will accept any value type with no complaints from TypeScript:

```ts
const obj = { foo: 1 };
D.set(obj, 'foo', 'uh oh'); // wrong type, but no TypeScript errors
```kL

With the updated types in this commit, not only does TypeScript now give errors for mistyped values, but VS Code also does autocomplete for keys. 😎

You can still pass in non-existing keys to add them to the object, in which case `value` can be any type.
