### PR TITLE
Add missing methods to `AsyncResult`

### DIFF
--- a/__tests__/AsyncResult/isError.test.ts
+++ b/__tests__/AsyncResult/isError.test.ts
@@ -1,0 +1,19 @@
+import { expectType } from 'ts-expect'
+
+import { AR, pipe } from '../..'
+
+describe('isError', () => {
+  it('provides correct types', () => {
+    expectType<boolean>(AR.isError(AR.resolve("")))
+  })
+
+  it('returns true', () => {
+    expect(AR.isError(AR.reject(""))).toBeTruthy()
+    expect(pipe(AR.reject(""), AR.isError)).toBeTruthy()
+  })
+
+  it('returns false', () => {
+    expect(AR.isError(AR.resolve(""))).toBeFalsy()
+    expect(pipe(AR.resolve(""), AR.isError)).toBeFalsy()
+  })
+})

--- a/__tests__/AsyncResult/isOk.test.ts
+++ b/__tests__/AsyncResult/isOk.test.ts
@@ -1,0 +1,19 @@
+import { expectType } from 'ts-expect'
+
+import { AR, pipe } from '../..'
+
+describe('isOk', () => {
+  it('provides correct types', () => {
+    expectType<boolean>(AR.isOk(AR.resolve("")))
+  })
+
+  it('returns true', () => {
+    expect(AR.isOk(AR.resolve(""))).toBeTruthy()
+    expect(pipe(AR.resolve(""), AR.isOk)).toBeTruthy()
+  })
+
+  it('returns false', () => {
+    expect(AR.isOk(AR.reject(""))).toBeFalsy()
+    expect(pipe(AR.reject(""), AR.isOk)).toBeFalsy()
+  })
+})

--- a/src/AsyncResult/AsyncResult.res
+++ b/src/AsyncResult/AsyncResult.res
@@ -56,6 +56,22 @@ let filter = (promise, predicateFn) => {
 }
 
 @gentype
+let isOk = result => {
+  switch result {
+  | Ok(_) => true
+  | Error(_) => false
+  }
+}
+
+@gentype
+let isError = result => {
+  switch result {
+  | Ok(_) => false
+  | Error(_) => true
+  }
+}
+
+@gentype
 let match = (promise, okFn, errorFn) => {
   promise->thenResolve(option => {
     switch option {


### PR DESCRIPTION
Fixes https://github.com/mobily/ts-belt/issues/94.

Note that several of the tests currently fail.