### PR TITLE
fix: match Result's type to its compiled output

### DIFF
--- a/src/Result/Result.ts
+++ b/src/Result/Result.ts
@@ -3,11 +3,11 @@ import { Option } from '../Option'
 export declare type Ok<T> = {
   readonly TAG: 0
   readonly _0: T
-} & { __: 'Ok' }
+}
 export declare type Error<T> = {
   readonly TAG: 1
   readonly _0: T
-} & { __: 'Error' }
+}
 
 export declare type Result<A, B> = Ok<A> | Error<B>
 

--- a/src/Result/index.ts
+++ b/src/Result/index.ts
@@ -2,11 +2,11 @@ import { Option } from '../Option'
 export declare type Ok<T> = {
   readonly TAG: 0
   readonly _0: T
-} & { __: 'Ok' }
+}
 export declare type Error<T> = {
   readonly TAG: 1
   readonly _0: T
-} & { __: 'Error' }
+}
 
 export declare type Result<A, B> = Ok<A> | Error<B>
 


### PR DESCRIPTION
currently, the type of Result in ts-belt has `__` field, which is supposed to be 'Ok' | 'Error' for identifying its subtype. but the structure of the build output from the rescript compiler doesn't have those fields. This PR resolves these mismatches, as not so confuse developers who try to access __ field