### PR TITLE
fix: no BS_NESTED_SOME_NONE when literal none passed to AsyncResult

### DIFF
--- a/src/AsyncResult/AsyncResult.res
+++ b/src/AsyncResult/AsyncResult.res
@@ -66,12 +66,13 @@ let match = (promise, okFn, errorFn) => {
 }
 
 @gentype
-let toOption = promise => {
-  promise->thenResolve(option => {
-    switch option {
+let toOption = asyncResult => {
+  asyncResult->thenResolve(result => {
+    switch result {
+    | Ok(None) => None
     | Ok(value) => Some(value)
     | Error(_) => None
-    }
+    }->Js.Promise.resolve
   })
 }
 


### PR DESCRIPTION
resolves #96 

<img width="164" alt="image" src="https://github.com/mobily/ts-belt/assets/7118300/cf482028-0a14-46e0-856a-fe15bebbe712">

passes following code.
```
const toOptionTest = async () => {
  const option = await pipe(AR.resolve(undefined), AR.toOption);

  console.log('option is:', option);

  O.match(
    option,
    () => {
      console.log('option is `Some`');
    },
    () => {
      console.log('option is `None`');
    },
  );

  return option;
};

void toOptionTest();
```